### PR TITLE
Fix resource leak in benchmark

### DIFF
--- a/src/main/java/info/boaventura/bench/Main.java
+++ b/src/main/java/info/boaventura/bench/Main.java
@@ -24,6 +24,8 @@ public class Main {
     } catch (Exception e) {
       System.err.println("*** Erreur benching: " + e.getMessage());
     } finally {
+      // close resources even in case of errors
+      copierNewIOBufferReadBenchmark.close();
       copierNewIOBufferReadBenchmark.summary();
       copierNewIOBufferReadBenchmark.cleanup();
       printHead();


### PR DESCRIPTION
## Summary
- ensure copier implementations are closed when running a benchmark

## Testing
- `mvn -q -e -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_68417dd89a00832a98023a826f12e5b2