### PR TITLE
Fix wording for CopierNewIOBufferRead2

### DIFF
--- a/src/main/java/info/boaventura/bench/CopierNewIOBufferRead2.java
+++ b/src/main/java/info/boaventura/bench/CopierNewIOBufferRead2.java
@@ -32,7 +32,7 @@ public class CopierNewIOBufferRead2 implements Copier {
   }
 
   public String getStrategy() {
-    return "Copie de NewIO avec bufferized MappedByteBuffer (BUFFER: " + BUFFER + ")";
+    return "Copie de NewIO avec direct ByteBuffer (BUFFER: " + BUFFER + ")";
   }
 
   public void read() throws IOException {


### PR DESCRIPTION
## Summary
- update description in `getStrategy()` to mention direct ByteBuffer

## Testing
- `mvn -q package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6841820d9c80832ab88c3c2bd5b46f45